### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        maven { url 'http://repo.springsource.org/plugins-release' }
+        maven { url 'https://repo.springsource.org/plugins-release' }
     }
     dependencies {
         classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.1.5'

--- a/original-samples/batch-wordcount/build.gradle
+++ b/original-samples/batch-wordcount/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'application'
 
 repositories {
     // Public Spring artefacts
-    maven { url "http://repo.springsource.org/libs-snapshot" }
+    maven { url "https://repo.springsource.org/libs-snapshot" }
 }
 
 //load version from the root folder

--- a/original-samples/cascading/build.gradle
+++ b/original-samples/cascading/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'application'
 
 repositories {
     // Public Spring artefacts
-    maven { url "http://repo.springsource.org/libs-snapshot" }
+    maven { url "https://repo.springsource.org/libs-snapshot" }
     mavenLocal()
 }
 

--- a/original-samples/hbase-crud/build.gradle
+++ b/original-samples/hbase-crud/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'eclipse'
 apply plugin: 'application'
 
 repositories {
-    maven { url "http://repo.springsource.org/libs-snapshot" }
+    maven { url "https://repo.springsource.org/libs-snapshot" }
 }
 
 //load version from the root folder

--- a/original-samples/pig-scripting/build.gradle
+++ b/original-samples/pig-scripting/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'application'
 
 repositories {
     // Public Spring artefacts
-    maven { url "http://repo.springsource.org/libs-snapshot" }
+    maven { url "https://repo.springsource.org/libs-snapshot" }
 }
 
 //load version from the root folder
@@ -35,7 +35,7 @@ dependencies {
 
 task downloadSampleSet(type:Copy) {
    if (!new File('src/main/resources/ml-100k.zip').isFile()) {
-    ant.get(src: 'http://www.grouplens.org/system/files/ml-100k.zip', 
+    ant.get(src: 'https://grouplens.org/system/files/ml-100k.zip', 
            dest: 'src/main/resources/', usetimestamp:true)
    }
    copy {

--- a/original-samples/wordcount/build.gradle
+++ b/original-samples/wordcount/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'application'
 
 repositories {
     // Public Spring artefacts
-    maven { url "http://repo.springsource.org/libs-snapshot" }
+    maven { url "https://repo.springsource.org/libs-snapshot" }
 }
 
 //load version from the root folder

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>spring-hadoop-shell-dist</artifactId>
     <version>1.0.0.BUILD-SNAPSHOT</version>
     <name>Spring Hadoop Samples Distribution</name>
-    <url>http://www.springsource.org/spring-data/hadoop</url>
+    <url>https://www.springsource.org/spring-data/hadoop</url>
     <packaging>pom</packaging>
     <modules>
         <module>server</module>
@@ -15,7 +15,7 @@
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
             <comments>
                 Copyright 2010 the original author or authors.
 
@@ -23,7 +23,7 @@
                 you may not use this file except in compliance with the License.
                 You may obtain a copy of the License at
 
-                http://www.apache.org/licenses/LICENSE-2.0
+                https://www.apache.org/licenses/LICENSE-2.0
 
                 Unless required by applicable law or agreed to in writing, software
                 distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/hive/pom.xml
+++ b/samples/hive/pom.xml
@@ -199,11 +199,11 @@
     <repositories>
         <repository>
             <id>spring-milestone</id>
-            <url>http://repo.springsource.org/libs-milestone</url>
+            <url>https://repo.springsource.org/libs-milestone</url>
         </repository>
         <repository>
             <id>spring-snapshot</id>
-            <url>http://repo.springsource.org/libs-snapshot</url>
+            <url>https://repo.springsource.org/libs-snapshot</url>
         </repository>
     </repositories>
 

--- a/samples/mapreduce/pom.xml
+++ b/samples/mapreduce/pom.xml
@@ -68,7 +68,7 @@
     <repositories>
         <repository>
             <id>spring-milestone</id>
-            <url>http://repo.springsource.org/libs-milestone</url>
+            <url>https://repo.springsource.org/libs-milestone</url>
         </repository>
     </repositories>
 

--- a/samples/pig/pom.xml
+++ b/samples/pig/pom.xml
@@ -112,7 +112,7 @@
     <repositories>
         <repository>
             <id>spring-milestone</id>
-            <url>http://repo.springsource.org/libs-milestone</url>
+            <url>https://repo.springsource.org/libs-milestone</url>
         </repository>
     </repositories>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -131,7 +131,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestones</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -394,13 +394,13 @@
     <repositories>
         <repository>
             <id>spring-milestone</id>
-            <url>http://repo.springsource.org/libs-milestone</url>
+            <url>https://repo.springsource.org/libs-milestone</url>
         </repository>
         <repository>
             <!-- Snapshots -->
             <id>spring-libs-snapshot</id>
             <name>Spring Maven SNAPSHOT Repository</name>
-            <url>http://repo.springsource.org/libs-snapshot</url>
+            <url>https://repo.springsource.org/libs-snapshot</url>
         </repository>
     </repositories>
     <build>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -143,13 +143,13 @@
     <repositories>
         <repository>
             <id>spring-milestone</id>
-            <url>http://repo.springsource.org/libs-milestone</url>
+            <url>https://repo.springsource.org/libs-milestone</url>
         </repository>
         <repository>
             <!-- Snapshots -->
             <id>spring-libs-snapshot</id>
             <name>Spring Maven SNAPSHOT Repository</name>
-            <url>http://repo.springsource.org/libs-snapshot</url>
+            <url>https://repo.springsource.org/libs-snapshot</url>
         </repository>
     </repositories>
     <build>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.grouplens.org/system/files/ml-100k.zip (301) migrated to:  
  https://grouplens.org/system/files/ml-100k.zip ([https](https://www.grouplens.org/system/files/ml-100k.zip) result SSLHandshakeException).

## Fixed Success 
These URLs were fixed successfully.

* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://repo.springsource.org/libs-milestone migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://repo.springsource.org/libs-snapshot migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).
* http://repo.springsource.org/plugins-release migrated to:  
  https://repo.springsource.org/plugins-release ([https](https://repo.springsource.org/plugins-release) result 301).
* http://www.springsource.org/spring-data/hadoop migrated to:  
  https://www.springsource.org/spring-data/hadoop ([https](https://www.springsource.org/spring-data/hadoop) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance