### PR TITLE
URL Cleanup

### DIFF
--- a/docs/src/reference/docbook/dev-guide/dev-spring-hadoop.xml
+++ b/docs/src/reference/docbook/dev-guide/dev-spring-hadoop.xml
@@ -30,7 +30,7 @@
   <para>Another project of interest to Hadoop developers is Spring
   Integration. Spring Integration provides an extension of the Spring
   programming model to support the well-known <link
-  xlink:href="http://www.eaipatterns.com">Enterprise Integration
+  xlink:href="https://www.enterpriseintegrationpatterns.com/">Enterprise Integration
   Patterns</link>. It enables lightweight messaging <emphasis
   role="italic">within</emphasis> Spring-based applications and supports
   integration with external systems via declarative adapters. These adapters
@@ -60,15 +60,15 @@
     scheduler, not replace a scheduler. As a lightweight solution, you can use
     Spring's built in scheduling support that will give you cron like and
     other basic scheduling trigger functionality. See the <link
-    xlink:href="http://static.springsource.org/spring-batch/faq.html#schedulers">Task
+    xlink:href="https://docs.spring.io/spring-batch/faq.html#schedulers">Task
     Execution and Scheduling</link> documention for more info. A middle
     ground it to use Spring's Quartz integration, see <link
-    xlink:href="http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/scheduling.html#scheduling-quartz">Using
+    xlink:href="https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/scheduling.html#scheduling-quartz">Using
     the OpenSymphony Quartz Scheduler</link> for more information. The Spring
     Batch distribution contains an example, but this documentation will be
     updated to provide some more directed examples with Hadoop, check for
     updates on the <link
-    xlink:href="http://www.springsource.org/spring-data/hadoop">main web site
+    xlink:href="https://www.springsource.org/spring-data/hadoop">main web site
     of Spring for Apache Hadoop</link>.</para>
   </section>
 
@@ -79,7 +79,7 @@
     to perform additional processing. For example, at the end of a job you can
     perform some notification or perhaps even start another Spring Batch Jobs.
     As a brief example, implement the interface <link
-    xlink:href="http://static.springsource.org/spring-batch/apidocs/org/springframework/batch/core/JobExecutionListener.html">JobExecutionListener</link>
+    xlink:href="https://docs.spring.io/spring-batch/apidocs/org/springframework/batch/core/JobExecutionListener.html">JobExecutionListener</link>
     and configure it into the Spring Batch job as shown below.</para>
 
     <programlisting language="xml">&lt;batch:job id="job1"&gt;

--- a/docs/src/reference/docbook/introduction/getting-started.xml
+++ b/docs/src/reference/docbook/introduction/getting-started.xml
@@ -35,23 +35,23 @@
     map-reduce, to Hive, Pig, and HBase. </para>
 
     <para>To learn more about Spring Batch, visit the <link
-    ns6:href="http://static.springsource.org/spring-batch/">Spring Batch
+    ns6:href="https://docs.spring.io/spring-batch/">Spring Batch
     project page</link>. There are also two books available.</para>
 
     <itemizedlist>
       <listitem>
-        <para><link ns6:href="http://www.manning.com/templier/">Spring Batch
+        <para><link ns6:href="https://www.manning.com/templier/">Spring Batch
         in Action</link> - October 2011 - Manning</para>
       </listitem>
 
       <listitem>
-        <para><link ns6:href="http://www.apress.com/9781430234524">Pro Spring
+        <para><link ns6:href="https://www.apress.com/9781430234524">Pro Spring
         Batch</link> - July 18, 2011 - APress</para>
       </listitem>
     </itemizedlist>
 
     <para>A <link
-    ns6:href="http://www.manning.com/free/green_templier.html">free
+    ns6:href="https://www.manning.com/free/green_templier.html">free
     introduction chapter</link> is available from the the Spring Batch in
     Action book.</para>
   </section>

--- a/docs/src/reference/docbook/introduction/requirements.xml
+++ b/docs/src/reference/docbook/introduction/requirements.xml
@@ -5,13 +5,13 @@
   <title>Requirements</title>
 
   <para>Spring for Apache Hadoop requires JDK level 6.0 (just like Hadoop) and above,
-  Spring <ulink url="http://www.springsource.org/about">Framework</ulink> 3.0
+  Spring <ulink url="https://www.springsource.org/about">Framework</ulink> 3.0
   (3.1 recommended) and above and <ulink
-  url="http://www.gemstone.com/products/gemfire">Hadoop</ulink> 0.20.2
+  url="https://www.gemstone.com/products/gemfire">Hadoop</ulink> 0.20.2
   (1.0.0 recommended) and above. Regarding Hadoop-related projects, SDHP
-  supports <ulink url="http://hbase.apache.org/">HBase</ulink> 0.90.x, <ulink
-  url="http://hive.apache.org/">Hive</ulink> 0.7.x and <ulink
-  url="http://pig.apache.org/">Pig</ulink> 0.9.x and above. As a rule of
+  supports <ulink url="https://hbase.apache.org/">HBase</ulink> 0.90.x, <ulink
+  url="https://hive.apache.org/">Hive</ulink> 0.7.x and <ulink
+  url="https://pig.apache.org/">Pig</ulink> 0.9.x and above. As a rule of
   thumb, when using Hadoop-related projects, such as Hive or Pig, use the
   required Hadoop version as a basis for discovering the supported
   versions.</para>
@@ -20,10 +20,10 @@
   running. If you don't already have a Hadoop cluster up and running in your
   environment, a good first step is to create a single-node cluster. To
   install Hadoop 0.20.x+, the <link
-  ns6:href="http://hadoop.apache.org/common/docs/stable/#Getting+Started">Getting
+  ns6:href="https://hadoop.apache.org/common/docs/stable/#Getting+Started">Getting
   Started</link> page from the official Apache documentation is a good general guide.
   If you are running on Ubuntu, the tutorial from Michael G. Noll, "<link
-  ns6:href="http://www.michael-noll.com/tutorials/running-hadoop-on-ubuntu-linux-single-node-cluster/">Running
+  ns6:href="https://www.michael-noll.com/tutorials/running-hadoop-on-ubuntu-linux-single-node-cluster/">Running
   Hadoop On Ubuntu Linux (Single-Node Cluster)</link>" provides more details.
   It is also convenience to download a Virtual Machine where Hadoop is setup
   and ready to go. Cloudera provides virtual machines of various formats <link
@@ -31,6 +31,6 @@
   You can also download the <link
   ns6:href="http://www.greenplum.com/products/greenplum-hd">EMC Greenplum
   HD</link> distribution or get a tech preview of the <link
-  ns6:href="http://hortonworks.com/technology/techpreview/">Hortonworks
+  ns6:href="https://hortonworks.com/technology/techpreview/">Hortonworks
   distribution</link>.</para>
 </chapter>

--- a/docs/src/reference/docbook/links.xml
+++ b/docs/src/reference/docbook/links.xml
@@ -4,10 +4,10 @@
 
 	<itemizedlist>
 
-    <listitem><emphasis>Spring for Apache Hadoop </emphasis> - <ulink url="http://www.springframework.org/spring-data/hadoop">Home Page</ulink></listitem>
-    <listitem><emphasis>Spring Data </emphasis> - <ulink url="http://www.springframework.org/spring-data">Home Page</ulink></listitem>
-    <listitem><emphasis>SpringSource </emphasis> - <ulink url="http://blog.springsource.com/">Blog</ulink></listitem>
-    <listitem><emphasis>Hadoop </emphasis> - <ulink url="http://hadoop.apache.org/">Home Page</ulink></listitem>
-	<listitem><emphasis>Spring Hadoop Team on Twitter</emphasis> - <ulink url="http://twitter.com/costinl">Costin</ulink></listitem>
+    <listitem><emphasis>Spring for Apache Hadoop </emphasis> - <ulink url="https://www.springframework.org/spring-data/hadoop">Home Page</ulink></listitem>
+    <listitem><emphasis>Spring Data </emphasis> - <ulink url="https://www.springframework.org/spring-data">Home Page</ulink></listitem>
+    <listitem><emphasis>SpringSource </emphasis> - <ulink url="https://spring.io/blog/">Blog</ulink></listitem>
+    <listitem><emphasis>Hadoop </emphasis> - <ulink url="https://hadoop.apache.org/">Home Page</ulink></listitem>
+	<listitem><emphasis>Spring Hadoop Team on Twitter</emphasis> - <ulink url="https://twitter.com/costinl">Costin</ulink></listitem>
 	</itemizedlist>
 </chapter>

--- a/docs/src/reference/docbook/samples/spring-batch-wordcount.xml
+++ b/docs/src/reference/docbook/samples/spring-batch-wordcount.xml
@@ -23,7 +23,7 @@
 
     <para>The sample uses the Spring for Apache Hadoop namespace to define a Spring Batch
     Tasklet that runs a Hadoop job. A <link
-    xlink:href="http://static.springsource.org/spring-batch/reference/html/domain.html#domainJob">Spring
+    xlink:href="https://docs.spring.io/spring-batch/reference/html/domain.html#domainJob">Spring
     Batch Job</link> (not to be confused with a Hadoop job) combines multiple
     steps together to create a flow of execution, a small workflow. Each step
     in the flow does some processing which can be as complex or as simple as
@@ -31,7 +31,7 @@
     very simple, a linear sequence of steps, or complex using conditional and
     programmatic branching as well as sequential and parallel step execution.
     A <link
-    xlink:href="http://static.springsource.org/spring-batch/apidocs/org/springframework/batch/core/step/tasklet/Tasklet.html">Spring
+    xlink:href="https://docs.spring.io/spring-batch/apidocs/org/springframework/batch/core/step/tasklet/Tasklet.html">Spring
     Batch Tasklet</link> is the abstraction that represents the processing for
     a Step and is an extensible part of Spring Batch. You can write your own
     implementation of a Tasklet to perform arbitrary processing, but often you
@@ -72,7 +72,7 @@
     definitions that will be shown a little later.</para>
 
     <para>The <link
-    xlink:href="http://www.springsource.com/developer/sts">Spring Source
+    xlink:href="https://www.springsource.com/developer/sts">Spring Source
     Toolsuite</link> is a free Eclipse-powered development environment which
     provides a nice visualization and authoring help for Spring Batch
     workflows as shown below.<mediaobject>
@@ -106,7 +106,7 @@
     <para>The script makes use of the predefined variable fsh, which is the
     embedded <link linkend="scripting-fssh">Filesystem Shell</link> that
     Spring for Apache Hadoop provides. It also uses Spring's <link
-    xlink:href="http://static.springsource.org/spring/docs/3.1.x/spring-framework-reference/html/beans.html#beans-factory-placeholderconfigurer">Property
+    xlink:href="https://docs.spring.io/spring/docs/3.1.x/spring-framework-reference/html/beans.html#beans-factory-placeholderconfigurer">Property
     Placeholder</link> functionality so that the input and out paths can be
     configured external to the application, for example using property files.
     The syntax for variables recognized by Spring's Property Placeholder is
@@ -114,9 +114,9 @@
     <literal>/user/gutenberg/input/word</literal> and
     <literal>/user/gutenberg/output/word</literal> are the default input and
     output paths. Note you can also use <link
-    xlink:href="http://static.springsource.org/spring/docs/3.1.x/spring-framework-reference/html/expressions.html">Spring's
+    xlink:href="https://docs.spring.io/spring/docs/3.1.x/spring-framework-reference/html/expressions.html">Spring's
     Expression Language</link> to configure values in the script or in <link
-    xlink:href="http://static.springsource.org/spring/docs/3.1.x/spring-framework-reference/html/expressions.html#expressions-beandef">other
+    xlink:href="https://docs.spring.io/spring/docs/3.1.x/spring-framework-reference/html/expressions.html#expressions-beandef">other
     XML definitions</link>.</para>
 
     <para>The configuration of the tasklet to execute the Hadoop MapReduce
@@ -197,7 +197,7 @@
 
     <note>
       <para>If you run into some issues, drop us a line in the <link
-      xlink:href="http://forum.springsource.org/forumdisplay.php?27-Data">Spring
+      xlink:href="https://forum.spring.io/forumdisplay.php?27-Data">Spring
       Forums</link>.</para>
     </note>
   </section>
@@ -220,9 +220,9 @@
     <classname>org.springframework.batch.core.launch.support.CommandLineJobRunner</classname>.
     This main app requires you to specify at least a Spring configuration file
     and a job instance name. You can read the <literal>CommandLineJobRunner</literal> <link
-    xlink:href="http://static.springsource.org/spring-batch/apidocs/org/springframework/batch/core/launch/support/CommandLineJobRunner.html">JavaDocs</link>
+    xlink:href="https://docs.spring.io/spring-batch/apidocs/org/springframework/batch/core/launch/support/CommandLineJobRunner.html">JavaDocs</link>
     for more information as well as <link
-    xlink:href="http://static.springsource.org/spring-batch/reference/html/configureJob.html#runningJobsFromCommandLine">this
+    xlink:href="https://docs.spring.io/spring-batch/reference/html/configureJob.html#runningJobsFromCommandLine">this
     section in the reference docs</link> for Spring Batch to find out more of
     what command line options it supports.</para>
 

--- a/original-samples/batch-wordcount/src/main/resources/META-INF/spring/batch-common.xml
+++ b/original-samples/batch-wordcount/src/main/resources/META-INF/spring/batch-common.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="jobRepository" class="org.springframework.batch.core.repository.support.MapJobRepositoryFactoryBean"/>
 	<bean id="transactionManager" class="org.springframework.batch.support.transaction.ResourcelessTransactionManager"/>

--- a/original-samples/batch-wordcount/src/main/resources/META-INF/spring/hadoop-context.xml
+++ b/original-samples/batch-wordcount/src/main/resources/META-INF/spring/hadoop-context.xml
@@ -2,8 +2,8 @@
 <beans:beans xmlns="http://www.springframework.org/schema/hadoop"
 	xmlns:beans="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<!-- The value after the question mark is the default value if another value for hd.fs is not provided -->
 	<configuration file-system-uri="${hd.fs:hdfs://localhost:9000}"/>

--- a/original-samples/batch-wordcount/src/main/resources/META-INF/spring/wordcount-context.xml
+++ b/original-samples/batch-wordcount/src/main/resources/META-INF/spring/wordcount-context.xml
@@ -2,9 +2,9 @@
 <beans:beans xmlns="http://www.springframework.org/schema/hadoop"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:batch="http://www.springframework.org/schema/batch"
-	xsi:schemaLocation="http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.1.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.1.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<batch:job id="basicJob">
 		<batch:step id="import" next="wordcount">

--- a/original-samples/batch-wordcount/src/main/resources/launch-context.xml
+++ b/original-samples/batch-wordcount/src/main/resources/launch-context.xml
@@ -3,8 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<context:property-placeholder location="classpath:batch.properties,classpath:hadoop.properties"
 			ignore-resource-not-found="true" ignore-unresolvable="true" />

--- a/original-samples/cascading/src/main/resources/META-INF/spring/cascading.xml
+++ b/original-samples/cascading/src/main/resources/META-INF/spring/cascading.xml
@@ -3,8 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:c="http://www.springframework.org/schema/c"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 		
   	<hdp:script id="copyDataToHdfs" language="javascript" run-at-startup="true">
         // set the proper path separator on Win systems - see HADOOP-9123

--- a/original-samples/cascading/src/main/resources/META-INF/spring/context.xml
+++ b/original-samples/cascading/src/main/resources/META-INF/spring/context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="hadoop-ctx.xml"/>
 	<import resource="cascading.xml"/>

--- a/original-samples/cascading/src/main/resources/META-INF/spring/hadoop-ctx.xml
+++ b/original-samples/cascading/src/main/resources/META-INF/spring/hadoop-ctx.xml
@@ -1,8 +1,8 @@
 <hdp xmlns="http://www.springframework.org/schema/hadoop"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:property-placeholder location="hadoop.properties"/>
 

--- a/original-samples/hbase-crud/src/main/resources/META-INF/spring/context.xml
+++ b/original-samples/hbase-crud/src/main/resources/META-INF/spring/context.xml
@@ -4,9 +4,9 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 
 	<context:property-placeholder location="hadoop.properties"/>

--- a/original-samples/pig-scripting/src/main/resources/META-INF/spring/batch-common.xml
+++ b/original-samples/pig-scripting/src/main/resources/META-INF/spring/batch-common.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="jobRepository" class="org.springframework.batch.core.repository.support.MapJobRepositoryFactoryBean"/>
 	<bean id="transactionManager" class="org.springframework.batch.support.transaction.ResourcelessTransactionManager"/>

--- a/original-samples/pig-scripting/src/main/resources/META-INF/spring/context.xml
+++ b/original-samples/pig-scripting/src/main/resources/META-INF/spring/context.xml
@@ -4,10 +4,10 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:batch="http://www.springframework.org/schema/batch"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	  http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-	  http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	  http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	  http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+	  http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd">
 
 
 	<import resource="batch-common.xml"/>

--- a/original-samples/wordcount/src/main/resources/META-INF/spring/context.xml
+++ b/original-samples/wordcount/src/main/resources/META-INF/spring/context.xml
@@ -4,9 +4,9 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 
 	<context:property-placeholder location="hadoop.properties"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.springframework.samples</groupId>
     <artifactId>spring-hadoop-shell-dist</artifactId>
     <version>1.0.0.BUILD-SNAPSHOT</version>
     <name>Spring Hadoop Samples Distribution</name>
-    <url>http://www.springsource.org/spring-data/hadoop</url>
+    <url>https://www.springsource.org/spring-data/hadoop</url>
     <packaging>pom</packaging>
     <modules>
         <module>server</module>

--- a/samples/hive/pom.xml
+++ b/samples/hive/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>spring-hadoop-samples-hive</artifactId>
@@ -199,11 +199,11 @@
     <repositories>
         <repository>
             <id>spring-milestone</id>
-            <url>http://repo.springsource.org/libs-milestone</url>
+            <url>https://repo.springsource.org/libs-milestone</url>
         </repository>
         <repository>
             <id>spring-snapshot</id>
-            <url>http://repo.springsource.org/libs-snapshot</url>
+            <url>https://repo.springsource.org/libs-snapshot</url>
         </repository>
     </repositories>
 

--- a/samples/hive/src/main/resources/META-INF/spring/hive-apache-log-context.xml
+++ b/samples/hive/src/main/resources/META-INF/spring/hive-apache-log-context.xml
@@ -3,9 +3,9 @@
 	xmlns:beans="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	  http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	  http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	  http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<context:property-placeholder location="hadoop.properties,hive.properties"/>
 

--- a/samples/hive/src/main/resources/META-INF/spring/hive-context.xml
+++ b/samples/hive/src/main/resources/META-INF/spring/hive-context.xml
@@ -3,9 +3,9 @@
 	xmlns:beans="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	  http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	  http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	  http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<beans:import resource="jdbc-context.xml"/>
 

--- a/samples/hive/src/main/resources/META-INF/spring/jdbc-context.xml
+++ b/samples/hive/src/main/resources/META-INF/spring/jdbc-context.xml
@@ -4,10 +4,10 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:batch="http://www.springframework.org/schema/batch"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	  http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-	  http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	  http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	  http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+	  http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd">
 
 	<bean id="hiveDriver" class="org.apache.hadoop.hive.jdbc.HiveDriver"/>
 	

--- a/samples/mapreduce/pom.xml
+++ b/samples/mapreduce/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>spring-hadoop-samples-mapreduce</artifactId>
@@ -68,7 +68,7 @@
     <repositories>
         <repository>
             <id>spring-milestone</id>
-            <url>http://repo.springsource.org/libs-milestone</url>
+            <url>https://repo.springsource.org/libs-milestone</url>
         </repository>
     </repositories>
 

--- a/samples/mapreduce/src/main/resources/META-INF/spring/application-context.xml
+++ b/samples/mapreduce/src/main/resources/META-INF/spring/application-context.xml
@@ -3,9 +3,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 
 	<context:property-placeholder location="hadoop.properties"/>

--- a/samples/pig/pom.xml
+++ b/samples/pig/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>spring-hadoop-samples-pig</artifactId>
@@ -112,7 +112,7 @@
     <repositories>
         <repository>
             <id>spring-milestone</id>
-            <url>http://repo.springsource.org/libs-milestone</url>
+            <url>https://repo.springsource.org/libs-milestone</url>
         </repository>
     </repositories>
 

--- a/samples/pig/src/main/resources/META-INF/spring/pig-context-apache-logs.xml
+++ b/samples/pig/src/main/resources/META-INF/spring/pig-context-apache-logs.xml
@@ -3,9 +3,9 @@
 	xmlns:beans="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	  http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	  http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	  http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 
 	<context:property-placeholder location="hadoop.properties,pig-analysis.properties"/>

--- a/samples/pig/src/main/resources/META-INF/spring/pig-context-password-repository.xml
+++ b/samples/pig/src/main/resources/META-INF/spring/pig-context-password-repository.xml
@@ -3,9 +3,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:beans="http://www.springframework.org/schema/beans"    
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	  http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	  http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	  http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 
 	<context:property-placeholder location="hadoop.properties"/>

--- a/samples/pig/src/main/resources/META-INF/spring/pig-context.xml
+++ b/samples/pig/src/main/resources/META-INF/spring/pig-context.xml
@@ -3,9 +3,9 @@
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 
 	<context:property-placeholder location="hadoop.properties"/>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.samples</groupId>
@@ -131,7 +131,7 @@
 	<repositories>
 		<repository>
 			<id>spring-milestones</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
+			<url>https://repo.springsource.org/libs-milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.springframework.data</groupId>
     <version>1.0.0.BUILD-SNAPSHOT</version>
@@ -394,13 +394,13 @@
     <repositories>
         <repository>
             <id>spring-milestone</id>
-            <url>http://repo.springsource.org/libs-milestone</url>
+            <url>https://repo.springsource.org/libs-milestone</url>
         </repository>
         <repository>
             <!-- Snapshots -->
             <id>spring-libs-snapshot</id>
             <name>Spring Maven SNAPSHOT Repository</name>
-            <url>http://repo.springsource.org/libs-snapshot</url>
+            <url>https://repo.springsource.org/libs-snapshot</url>
         </repository>
     </repositories>
     <build>

--- a/server/src/main/config/file-polling/application-context.xml
+++ b/server/src/main/config/file-polling/application-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:file="http://www.springframework.org/schema/integration/file"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.2.xsd
-		http://www.springframework.org/schema/integration/file http://www.springframework.org/schema/integration/file/spring-integration-file-2.2.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop-1.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.2.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration-2.2.xsd
+		http://www.springframework.org/schema/integration/file https://www.springframework.org/schema/integration/file/spring-integration-file-2.2.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop-1.0.xsd">
 
 	<context:property-placeholder location="properties/hadoop.properties,properties/polling.properties"/>
 

--- a/server/src/main/config/ftp/application-context.xml
+++ b/server/src/main/config/ftp/application-context.xml
@@ -5,11 +5,11 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
     xmlns:int-ftp="http://www.springframework.org/schema/integration/ftp"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
-	    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd
-	    http://www.springframework.org/schema/integration/ftp http://www.springframework.org/schema/integration/ftp/spring-integration-ftp-2.2.xsd
-	    http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.2.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop-1.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+	    http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.2.xsd
+	    http://www.springframework.org/schema/integration/ftp https://www.springframework.org/schema/integration/ftp/spring-integration-ftp-2.2.xsd
+	    http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration-2.2.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop-1.0.xsd">
 
 
 	<context:property-placeholder location="properties/ftp.properties,properties/hadoop.properties"/>

--- a/server/src/main/config/hive/hive-apache-log-context.xml
+++ b/server/src/main/config/hive/hive-apache-log-context.xml
@@ -3,9 +3,9 @@
 	xmlns:beans="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	  http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	  http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	  http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<context:property-placeholder location="hadoop.properties,hive/hive.properties"/>
 

--- a/server/src/main/config/hive/hive-context.xml
+++ b/server/src/main/config/hive/hive-context.xml
@@ -3,9 +3,9 @@
 	xmlns:beans="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	  http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	  http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	  http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<beans:import resource="jdbc-context.xml"/>
 

--- a/server/src/main/config/hive/jdbc-context.xml
+++ b/server/src/main/config/hive/jdbc-context.xml
@@ -4,10 +4,10 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:batch="http://www.springframework.org/schema/batch"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	  http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-	  http://www.springframework.org/schema/batch	http://www.springframework.org/schema/batch/spring-batch.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	  http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	  http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+	  http://www.springframework.org/schema/batch	https://www.springframework.org/schema/batch/spring-batch.xsd">
 
 	<bean id="hiveDriver" class="org.apache.hadoop.hive.jdbc.HiveDriver"/>
 	

--- a/server/src/main/config/input-adapters/syslog-udp.xml
+++ b/server/src/main/config/input-adapters/syslog-udp.xml
@@ -11,16 +11,16 @@
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:mvc="http://www.springframework.org/schema/mvc"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd
-		http://www.springframework.org/schema/integration/ip http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
-		http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
-		http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream-2.1.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/http https://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd
+		http://www.springframework.org/schema/integration/ip https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
+		http://www.springframework.org/schema/integration/jmx https://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
+		http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream-2.1.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-3.1.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
 	
     <int-ip:udp-inbound-channel-adapter id="inputAdapter" 

--- a/server/src/main/config/output-adapters/hdfs.xml
+++ b/server/src/main/config/output-adapters/hdfs.xml
@@ -11,16 +11,16 @@
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:mvc="http://www.springframework.org/schema/mvc"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd
-		http://www.springframework.org/schema/integration/ip http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
-		http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
-		http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream-2.1.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/http https://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd
+		http://www.springframework.org/schema/integration/ip https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
+		http://www.springframework.org/schema/integration/jmx https://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
+		http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream-2.1.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-3.1.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
 	<hdp:configuration register-url-handler="false">
 		fs.default.name=${hd.fs}

--- a/server/src/main/config/pig/pig-context-apache-logs.xml
+++ b/server/src/main/config/pig/pig-context-apache-logs.xml
@@ -3,9 +3,9 @@
 	xmlns:beans="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	  http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	  http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	  http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 
 	<context:property-placeholder location="properties/hadoop.properties,pig/pig-analysis.properties"/>

--- a/server/src/main/config/pig/pig-context-password-repository.xml
+++ b/server/src/main/config/pig/pig-context-password-repository.xml
@@ -3,9 +3,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:beans="http://www.springframework.org/schema/beans"    
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	  http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	  http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	  http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 
 	<context:property-placeholder location="hadoop.properties"/>

--- a/server/src/main/config/pig/pig-context.xml
+++ b/server/src/main/config/pig/pig-context.xml
@@ -3,9 +3,9 @@
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 
 	<context:property-placeholder location="properties/hadoop.properties,pig/pig-password.properties"/>

--- a/server/src/main/config/processors/noop.xml
+++ b/server/src/main/config/processors/noop.xml
@@ -11,16 +11,16 @@
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:mvc="http://www.springframework.org/schema/mvc"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd
-		http://www.springframework.org/schema/integration/ip http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
-		http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
-		http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream-2.1.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/http https://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd
+		http://www.springframework.org/schema/integration/ip https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
+		http://www.springframework.org/schema/integration/jmx https://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
+		http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream-2.1.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-3.1.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
 
 

--- a/server/src/main/config/syslog-hdfs/application-context-old.xml
+++ b/server/src/main/config/syslog-hdfs/application-context-old.xml
@@ -11,16 +11,16 @@
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:mvc="http://www.springframework.org/schema/mvc"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd
-		http://www.springframework.org/schema/integration/ip http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
-		http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
-		http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream-2.1.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/http https://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd
+		http://www.springframework.org/schema/integration/ip https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
+		http://www.springframework.org/schema/integration/jmx https://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
+		http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream-2.1.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-3.1.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
 
 	<context:property-placeholder location="syslog-hdfs/hadoop-old.properties,syslog-hdfs/syslog-old.properties"/>

--- a/server/src/main/config/syslog-hdfs/application-context.xml
+++ b/server/src/main/config/syslog-hdfs/application-context.xml
@@ -11,16 +11,16 @@
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:mvc="http://www.springframework.org/schema/mvc"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd
-		http://www.springframework.org/schema/integration/ip http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
-		http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
-		http://www.springframework.org/schema/integration/stream http://www.springframework.org/schema/integration/stream/spring-integration-stream-2.1.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/http https://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd
+		http://www.springframework.org/schema/integration/ip https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
+		http://www.springframework.org/schema/integration/jmx https://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
+		http://www.springframework.org/schema/integration/stream https://www.springframework.org/schema/integration/stream/spring-integration-stream-2.1.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-3.1.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
 
 	<context:property-placeholder

--- a/server/src/main/config/syslog-hdfs/hadoop-context.xml
+++ b/server/src/main/config/syslog-hdfs/hadoop-context.xml
@@ -4,9 +4,9 @@
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 
 	<context:property-placeholder location="hadoop.properties"/>

--- a/server/src/main/config/wordcount/application-context.xml
+++ b/server/src/main/config/wordcount/application-context.xml
@@ -3,9 +3,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 
 	<context:property-placeholder location="properties/hadoop.properties,properties/wordcount.properties"/>

--- a/server/src/main/resources/META-INF/spring/batch/initialize/initialize-batch-schema-context.xml
+++ b/server/src/main/resources/META-INF/spring/batch/initialize/initialize-batch-schema-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
 
 	<jdbc:initialize-database data-source="dataSource">
 		<jdbc:script location="classpath:/org/springframework/batch/core/schema-h2.sql"/>

--- a/server/src/main/resources/META-INF/spring/batch/initialize/initialize-product-export-table-context.xml
+++ b/server/src/main/resources/META-INF/spring/batch/initialize/initialize-product-export-table-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
 
 	<jdbc:initialize-database data-source="dataSource">
 		<jdbc:script location="classpath:/create-product-export-table.sql" />

--- a/server/src/main/resources/META-INF/spring/batch/initialize/initialize-product-table-context.xml
+++ b/server/src/main/resources/META-INF/spring/batch/initialize/initialize-product-table-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
 
 	<jdbc:initialize-database data-source="dataSource">
 		<jdbc:script location="classpath:/create-and-populate-product-table.sql" />

--- a/server/src/main/resources/META-INF/spring/batch/jobs/export-from-hdfs-context.xml
+++ b/server/src/main/resources/META-INF/spring/batch/jobs/export-from-hdfs-context.xml
@@ -5,11 +5,11 @@
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:mongo="http://www.springframework.org/schema/data/mongo"	
 	xsi:schemaLocation="http://www.springframework.org/schema/beans 
-	http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
 	http://www.springframework.org/schema/batch 
-	http://www.springframework.org/schema/batch/spring-batch-2.1.xsd
-	http://www.springframework.org/schema/data/mongo http://www.springframework.org/schema/data/mongo/spring-mongo.xsd	
-	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	https://www.springframework.org/schema/batch/spring-batch-2.1.xsd
+	http://www.springframework.org/schema/data/mongo https://www.springframework.org/schema/data/mongo/spring-mongo.xsd	
+	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 
 	<import resource="classpath:/META-INF/spring/hadoop-context.xml"/>

--- a/server/src/main/resources/META-INF/spring/batch/jobs/import-to-hdfs-context.xml
+++ b/server/src/main/resources/META-INF/spring/batch/jobs/import-to-hdfs-context.xml
@@ -4,10 +4,10 @@
 	xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans 
-	http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
 	http://www.springframework.org/schema/batch 
-	http://www.springframework.org/schema/batch/spring-batch-2.1.xsd
-	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	https://www.springframework.org/schema/batch/spring-batch-2.1.xsd
+	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<import resource="classpath:/META-INF/spring/hadoop-context.xml"/>
 	

--- a/server/src/main/resources/META-INF/spring/batch/jobs/wordcount-context.xml
+++ b/server/src/main/resources/META-INF/spring/batch/jobs/wordcount-context.xml
@@ -5,10 +5,10 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 	xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd
-	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-	http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd
+	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+	http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<beans:import resource="classpath:/META-INF/spring/hadoop-context.xml"/>
 	

--- a/server/src/main/resources/META-INF/spring/batch/override/batch-infrastructure-context.xml
+++ b/server/src/main/resources/META-INF/spring/batch/override/batch-infrastructure-context.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:batch="http://www.springframework.org/schema/batch"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.1.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.1.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.2.xsd">
 
 	<import resource="classpath:/META-INF/spring/batch/override/datasource-context.xml"/>
 	

--- a/server/src/main/resources/META-INF/spring/batch/override/datasource-context.xml
+++ b/server/src/main/resources/META-INF/spring/batch/override/datasource-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:batch="http://www.springframework.org/schema/batch"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.1.xsd">
 
 	<bean id="dataSource" class="org.springframework.jdbc.datasource.SingleConnectionDataSource">
 		<property name="driverClassName" value="org.h2.Driver" />

--- a/server/src/main/resources/META-INF/spring/hadoop-context.xml
+++ b/server/src/main/resources/META-INF/spring/hadoop-context.xml
@@ -4,9 +4,9 @@
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/hadoop https://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 
 	<context:property-placeholder location="classpath*:/META-INF/spring/hadoop.properties"/>

--- a/server/src/main/resources/META-INF/webapp/web.xml
+++ b/server/src/main/resources/META-INF/webapp/web.xml
@@ -2,7 +2,7 @@
 <web-app xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
 			http://java.sun.com/xml/ns/j2ee
-			http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd" version="2.4">
+			https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd" version="2.4">
 
 	<context-param>
 		<param-name>contextConfigLocation</param-name>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.springframework.samples</groupId>
     <artifactId>spring-data-hadoop-shell</artifactId>
@@ -143,13 +143,13 @@
     <repositories>
         <repository>
             <id>spring-milestone</id>
-            <url>http://repo.springsource.org/libs-milestone</url>
+            <url>https://repo.springsource.org/libs-milestone</url>
         </repository>
         <repository>
             <!-- Snapshots -->
             <id>spring-libs-snapshot</id>
             <name>Spring Maven SNAPSHOT Repository</name>
-            <url>http://repo.springsource.org/libs-snapshot</url>
+            <url>https://repo.springsource.org/libs-snapshot</url>
         </repository>
     </repositories>
     <build>

--- a/shell/src/main/resources/META-INF/spring/spring-shell-plugin.xml
+++ b/shell/src/main/resources/META-INF/spring/spring-shell-plugin.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
     <context:component-scan base-package="org.springframework.data.hadoop.shell"/>
 

--- a/shell/src/main/resources/rest-context.xml
+++ b/shell/src/main/resources/rest-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<bean id="restTemplate" class="org.springframework.web.client.RestTemplate">
 		<!-- 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.greenplum.com/products/greenplum-hd (400) with 1 occurrences could not be migrated:  
   ([https](https://www.greenplum.com/products/greenplum-hd) result ClosedChannelException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.gemstone.com/products/gemfire (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://www.gemstone.com/products/gemfire ([https](https://www.gemstone.com/products/gemfire) result ConnectTimeoutException).
* http://hadoop.apache.org/common/docs/stable/ (404) with 1 occurrences migrated to:  
  https://hadoop.apache.org/common/docs/stable/ ([https](https://hadoop.apache.org/common/docs/stable/) result 404).
* http://www.springframework.org/spring-data (404) with 1 occurrences migrated to:  
  https://www.springframework.org/spring-data ([https](https://www.springframework.org/spring-data) result 404).
* http://www.springframework.org/spring-data/hadoop (404) with 1 occurrences migrated to:  
  https://www.springframework.org/spring-data/hadoop ([https](https://www.springframework.org/spring-data/hadoop) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/scheduling.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/spring-framework-reference/html/scheduling.html ([https](https://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/scheduling.html) result 200).
* http://static.springsource.org/spring/docs/3.1.x/spring-framework-reference/html/beans.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.1.x/spring-framework-reference/html/beans.html ([https](https://static.springsource.org/spring/docs/3.1.x/spring-framework-reference/html/beans.html) result 200).
* http://static.springsource.org/spring/docs/3.1.x/spring-framework-reference/html/expressions.html (301) with 2 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.1.x/spring-framework-reference/html/expressions.html ([https](https://static.springsource.org/spring/docs/3.1.x/spring-framework-reference/html/expressions.html) result 200).
* http://hadoop.apache.org/ with 1 occurrences migrated to:  
  https://hadoop.apache.org/ ([https](https://hadoop.apache.org/) result 200).
* http://hbase.apache.org/ with 1 occurrences migrated to:  
  https://hbase.apache.org/ ([https](https://hbase.apache.org/) result 200).
* http://hive.apache.org/ with 1 occurrences migrated to:  
  https://hive.apache.org/ ([https](https://hive.apache.org/) result 200).
* http://maven.apache.org/xsd/maven-4.0.0.xsd with 6 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://pig.apache.org/ with 1 occurrences migrated to:  
  https://pig.apache.org/ ([https](https://pig.apache.org/) result 200).
* http://blog.springsource.com/ (301) with 1 occurrences migrated to:  
  https://spring.io/blog/ ([https](https://blog.springsource.com/) result 200).
* http://twitter.com/costinl with 1 occurrences migrated to:  
  https://twitter.com/costinl ([https](https://twitter.com/costinl) result 200).
* http://www.eaipatterns.com (302) with 1 occurrences migrated to:  
  https://www.enterpriseintegrationpatterns.com/ ([https](https://www.eaipatterns.com) result 200).
* http://www.michael-noll.com/tutorials/running-hadoop-on-ubuntu-linux-single-node-cluster/ with 1 occurrences migrated to:  
  https://www.michael-noll.com/tutorials/running-hadoop-on-ubuntu-linux-single-node-cluster/ ([https](https://www.michael-noll.com/tutorials/running-hadoop-on-ubuntu-linux-single-node-cluster/) result 200).
* http://www.springframework.org/schema/batch/spring-batch-2.1.xsd with 8 occurrences migrated to:  
  https://www.springframework.org/schema/batch/spring-batch-2.1.xsd ([https](https://www.springframework.org/schema/batch/spring-batch-2.1.xsd) result 200).
* http://www.springframework.org/schema/batch/spring-batch.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/batch/spring-batch.xsd ([https](https://www.springframework.org/schema/batch/spring-batch.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 7 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.1.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.1.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.2.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.2.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.2.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 32 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.0.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.0.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.1.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.1.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.1.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.2.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.2.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.2.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context.xsd with 21 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* http://www.springframework.org/schema/data/mongo/spring-mongo.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/data/mongo/spring-mongo.xsd ([https](https://www.springframework.org/schema/data/mongo/spring-mongo.xsd) result 200).
* http://www.springframework.org/schema/hadoop/spring-hadoop-1.0.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/hadoop/spring-hadoop-1.0.xsd ([https](https://www.springframework.org/schema/hadoop/spring-hadoop-1.0.xsd) result 200).
* http://www.springframework.org/schema/hadoop/spring-hadoop.xsd with 31 occurrences migrated to:  
  https://www.springframework.org/schema/hadoop/spring-hadoop.xsd ([https](https://www.springframework.org/schema/hadoop/spring-hadoop.xsd) result 200).
* http://www.springframework.org/schema/integration/file/spring-integration-file-2.2.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/integration/file/spring-integration-file-2.2.xsd ([https](https://www.springframework.org/schema/integration/file/spring-integration-file-2.2.xsd) result 200).
* http://www.springframework.org/schema/integration/ftp/spring-integration-ftp-2.2.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/integration/ftp/spring-integration-ftp-2.2.xsd ([https](https://www.springframework.org/schema/integration/ftp/spring-integration-ftp-2.2.xsd) result 200).
* http://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd ([https](https://www.springframework.org/schema/integration/http/spring-integration-http-2.2.xsd) result 200).
* http://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd ([https](https://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd) result 200).
* http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd ([https](https://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd) result 200).
* http://www.springframework.org/schema/integration/spring-integration-2.2.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration-2.2.xsd ([https](https://www.springframework.org/schema/integration/spring-integration-2.2.xsd) result 200).
* http://www.springframework.org/schema/integration/spring-integration.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration.xsd ([https](https://www.springframework.org/schema/integration/spring-integration.xsd) result 200).
* http://www.springframework.org/schema/integration/stream/spring-integration-stream-2.1.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/integration/stream/spring-integration-stream-2.1.xsd ([https](https://www.springframework.org/schema/integration/stream/spring-integration-stream-2.1.xsd) result 200).
* http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd ([https](https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd) result 200).
* http://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd ([https](https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util-3.1.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util-3.1.xsd ([https](https://www.springframework.org/schema/util/spring-util-3.1.xsd) result 200).
* http://static.springsource.org/spring-batch/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch/ ([https](https://static.springsource.org/spring-batch/) result 301).
* http://static.springsource.org/spring-batch/apidocs/org/springframework/batch/core/JobExecutionListener.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch/apidocs/org/springframework/batch/core/JobExecutionListener.html ([https](https://static.springsource.org/spring-batch/apidocs/org/springframework/batch/core/JobExecutionListener.html) result 301).
* http://static.springsource.org/spring-batch/apidocs/org/springframework/batch/core/launch/support/CommandLineJobRunner.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch/apidocs/org/springframework/batch/core/launch/support/CommandLineJobRunner.html ([https](https://static.springsource.org/spring-batch/apidocs/org/springframework/batch/core/launch/support/CommandLineJobRunner.html) result 301).
* http://static.springsource.org/spring-batch/apidocs/org/springframework/batch/core/step/tasklet/Tasklet.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch/apidocs/org/springframework/batch/core/step/tasklet/Tasklet.html ([https](https://static.springsource.org/spring-batch/apidocs/org/springframework/batch/core/step/tasklet/Tasklet.html) result 301).
* http://static.springsource.org/spring-batch/faq.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch/faq.html ([https](https://static.springsource.org/spring-batch/faq.html) result 301).
* http://static.springsource.org/spring-batch/reference/html/configureJob.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch/reference/html/configureJob.html ([https](https://static.springsource.org/spring-batch/reference/html/configureJob.html) result 301).
* http://static.springsource.org/spring-batch/reference/html/domain.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch/reference/html/domain.html ([https](https://static.springsource.org/spring-batch/reference/html/domain.html) result 301).
* http://forum.springsource.org/forumdisplay.php?27-Data (301) with 1 occurrences migrated to:  
  https://forum.spring.io/forumdisplay.php?27-Data ([https](https://forum.springsource.org/forumdisplay.php?27-Data) result 301).
* http://hortonworks.com/technology/techpreview/ with 1 occurrences migrated to:  
  https://hortonworks.com/technology/techpreview/ ([https](https://hortonworks.com/technology/techpreview/) result 301).
* http://maven.apache.org/maven-v4_0_0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://repo.springsource.org/libs-milestone with 6 occurrences migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://repo.springsource.org/libs-snapshot with 3 occurrences migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).
* http://www.manning.com/free/green_templier.html with 1 occurrences migrated to:  
  https://www.manning.com/free/green_templier.html ([https](https://www.manning.com/free/green_templier.html) result 301).
* http://www.manning.com/templier/ with 1 occurrences migrated to:  
  https://www.manning.com/templier/ ([https](https://www.manning.com/templier/) result 301).
* http://www.springsource.org/spring-data/hadoop with 2 occurrences migrated to:  
  https://www.springsource.org/spring-data/hadoop ([https](https://www.springsource.org/spring-data/hadoop) result 301).
* http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd ([https](https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd) result 302).
* http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).
* http://www.springsource.org/about with 1 occurrences migrated to:  
  https://www.springsource.org/about ([https](https://www.springsource.org/about) result 302).
* http://www.apress.com/9781430234524 with 1 occurrences migrated to:  
  https://www.apress.com/9781430234524 ([https](https://www.apress.com/9781430234524) result 303).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 15 occurrences
* http://jakarta.apache.org/log4j/ with 1 occurrences
* http://java.sun.com/xml/ns/j2ee with 2 occurrences
* http://maven.apache.org/POM/4.0.0 with 14 occurrences
* http://www.springframework.org/schema/batch with 27 occurrences
* http://www.springframework.org/schema/beans with 86 occurrences
* http://www.springframework.org/schema/c with 3 occurrences
* http://www.springframework.org/schema/context with 62 occurrences
* http://www.springframework.org/schema/data/mongo with 2 occurrences
* http://www.springframework.org/schema/hadoop with 66 occurrences
* http://www.springframework.org/schema/integration with 14 occurrences
* http://www.springframework.org/schema/integration/file with 2 occurrences
* http://www.springframework.org/schema/integration/ftp with 2 occurrences
* http://www.springframework.org/schema/integration/http with 10 occurrences
* http://www.springframework.org/schema/integration/ip with 10 occurrences
* http://www.springframework.org/schema/integration/jmx with 10 occurrences
* http://www.springframework.org/schema/integration/stream with 10 occurrences
* http://www.springframework.org/schema/jdbc with 8 occurrences
* http://www.springframework.org/schema/mvc with 10 occurrences
* http://www.springframework.org/schema/p with 11 occurrences
* http://www.springframework.org/schema/util with 10 occurrences
* http://www.w3.org/1998/Math/MathML with 5 occurrences
* http://www.w3.org/1999/xhtml with 5 occurrences
* http://www.w3.org/1999/xlink with 7 occurrences
* http://www.w3.org/2000/svg with 5 occurrences
* http://www.w3.org/2001/XInclude with 5 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 52 occurrences